### PR TITLE
Remove extraneous newline from Swift template

### DIFF
--- a/configen/FileTemplates.swift
+++ b/configen/FileTemplates.swift
@@ -103,7 +103,7 @@ struct SwiftTemplate: ImplementationTemplate {
   
   var outputImplementationFileName: String { return "\(optionsParser.outputClassDirectory)/\(optionsParser.outputClassName).swift" }
   
-  var implementationBody: String { return "\n\nclass \(optionsParser.outputClassName) {\n\(bodyToken)\n}\n\n" }
+  var implementationBody: String { return "\n\nclass \(optionsParser.outputClassName) {\n\(bodyToken)\n}\n" }
 
   var integerImplementation: String { return "  static let \(variableNameToken): Int = \(valueToken)" }
   var doubleImplementation: String { return "  static let \(variableNameToken): Double = \(valueToken)" }

--- a/configen/FileTemplates.swift
+++ b/configen/FileTemplates.swift
@@ -80,7 +80,7 @@ struct ObjectiveCTemplate: HeaderTemplate, ImplementationTemplate {
 
   var implementationImportStatements: String { return "#import \"\(optionsParser.outputClassName).h\"" }
   
-  var implementationBody: String { return "\n\n@implementation \(optionsParser.outputClassName) \n\(bodyToken)\n@end\n\n" }
+  var implementationBody: String { return "\n\n@implementation \(optionsParser.outputClassName) \n\(bodyToken)\n@end\n" }
 
   var integerImplementation: String { return integerDeclaration + "\n{\n  return @\(valueToken);\n}" }
   var doubleImplementation: String { return doubleDeclaration + "\n{\n  return @\(valueToken);\n}" }


### PR DESCRIPTION
SwiftLint hates double newlines. And so do I.