### PR TITLE
Wraps string values in quotes when using a string array

### DIFF
--- a/configen/FileGenerator.swift
+++ b/configen/FileGenerator.swift
@@ -148,6 +148,10 @@ struct FileGenerator {
     rawValueStr = String(rawValueStr.dropLast()) // drop )
 
     rawValueStr = rawValueStr.trimmingCharacters(in: .whitespacesAndNewlines)
+    
+    if rawTypeCopy == "String" {
+      return "[\"\(rawValueStr)\"]"
+    }
 
     return "[\(rawValueStr)]"
   }


### PR DESCRIPTION
This PR is related to PR #39. But, now string values in an array are wrapped in quotes.

What was generated before:

```swift
static let arrayOfHashes: [String] = [abcdefg] // Won't compile
```

Generated after fix:

```swift
static let arrayOfHashes: [String] = ["abcdefg"]
```